### PR TITLE
#167289657: Update the logic behind creating a new favorite thing

### DIFF
--- a/favorite_things/settings.py
+++ b/favorite_things/settings.py
@@ -155,7 +155,7 @@ JWT_AUTH = {
     'JWT_AUTH_COOKIE': None,
 
     'JWT_RESPONSE_PAYLOAD_HANDLER':
-    'favoriteapi.utils.jwt_response_payload_handler',
+    'favoriteapi.utils.utils.jwt_response_payload_handler',
 
     'JWT_EXPIRATION_DELTA': datetime.timedelta(days=1),
     'JWT_SECRET_KEY': config('SECRET_KEY')

--- a/favoriteapi/tests/tests.py
+++ b/favoriteapi/tests/tests.py
@@ -182,6 +182,31 @@ class CategoryAPITest(BaseViewTest):
 
 
 class FavoriteAPITest(BaseViewTest):
+    def test_create_first_favorite_thing_in_category_with_invalid_ranking_fails(self):
+        self.user_token()
+        url = reverse(
+            "create-favorite",
+            kwargs={
+                "version": "v1"
+            }
+        )
+        data = {
+            "title": "nokia",
+            "description": "This is the first of its kind",
+            "ranking": 100,
+            "category": 1,
+            "metadata": {
+                "make": 2015,
+                "color": "black"
+            }
+        }
+        response = self.client.post(
+            url,
+            data=json.dumps(data),
+            content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_create_favorite_thing_success(self):
         self.user_token()
         url = reverse(

--- a/favoriteapi/utils/error_message_handler.py
+++ b/favoriteapi/utils/error_message_handler.py
@@ -1,0 +1,12 @@
+from rest_framework.exceptions import ValidationError
+from rest_framework import status
+
+
+def raise_error(message, status_code=status.HTTP_400_BAD_REQUEST):
+    err_obj = {
+        'status': 'error',
+        'message': message
+    }
+    error_message = ValidationError(err_obj)
+    error_message.status_code = status_code
+    raise error_message

--- a/favoriteapi/utils/utils.py
+++ b/favoriteapi/utils/utils.py
@@ -11,3 +11,4 @@ def jwt_response_payload_handler(token, user=None, request=None):
         'user': user.username,
         'expires': timezone.now() + expire_delta - datetime.timedelta(seconds=200)
     }
+


### PR DESCRIPTION
#### What does this PR do?
- This PR is to handle the inconsistencies in the logic for creating a new favourite thing instance
#### Description of Task to be completed?
- change the implementation behind creating a favourite thing
- write tests to cater for the new changes
#### How should this be manually tested?
- Navigate to the root directory for the local version of this project
- Run **python manage.py runserver** to start the application
- Navigate to the endpoint for creating a new favourite thing **http://127.0.0.1:8000/api/v1/favorite/**
- On providing valid details you should be able to create a new favourite thing with the **POST** method.
#### Any background context you want to provide?
- Previously the logic for creating favourite things allowed for randomly ordered creation which in the long run will cause issues when implementing the update logic for favourite things
#### What are the relevant pivotal tracker stories?
[#167289657](https://www.pivotaltracker.com/story/show/167289657)
