### PR TITLE
#167285522: Retrieve all their favorite things under a category

### DIFF
--- a/favorite_things/settings.py
+++ b/favorite_things/settings.py
@@ -132,7 +132,8 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.SessionAuthentication',
         'rest_framework_jwt.authentication.JSONWebTokenAuthentication',
-    )
+    ),
+    'DEFAULT_PAGINATION_CLASS': 'favoriteapi.pagination.FavoriteThingPagination',
 }
 
 JWT_AUTH = {

--- a/favoriteapi/models.py
+++ b/favoriteapi/models.py
@@ -30,3 +30,6 @@ class Favorite(models.Model):
     @property
     def owner(self):
         return self.user
+
+    class Meta:
+        ordering = ['ranking']

--- a/favoriteapi/pagination.py
+++ b/favoriteapi/pagination.py
@@ -1,0 +1,6 @@
+from rest_framework import pagination
+
+
+class FavoriteThingPagination(pagination.LimitOffsetPagination):
+    default_limit = 20
+    max_limit = 20

--- a/favoriteapi/tests/tests.py
+++ b/favoriteapi/tests/tests.py
@@ -247,6 +247,8 @@ class FavoriteAPITest(BaseViewTest):
         self.assertEqual(response.data['user']['username'], 'paddy')
 
     def test_create_favorite_thing_in_same_category_success(self):
+        user = User.objects.filter(username='paddy').first()
+        favorite = self.create_favorite(user=user, metadata={"size": "medium"})
         self.user_token(
             data={
                 "username": "paddy",
@@ -262,7 +264,7 @@ class FavoriteAPITest(BaseViewTest):
             "title": "motorola",
             "description": "This is the next big thing",
             "ranking": 1,
-            "category": 1,
+            "category": 2,
             "metadata": {
                 "make": 2019,
                 "color": "black"
@@ -624,3 +626,25 @@ class FavoriteAPITest(BaseViewTest):
             content_type="application/json"
         )
         self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+    def test_get_favorite_things_under_a_category_success(self):
+        user = User.objects.filter(username='pascal').first()
+        favorite = self.create_favorite(user=user, metadata={"size": "medium"})
+        self.user_token(
+            data={
+                "username": "pascal",
+                "password": "fakepassword"
+            })
+        url = reverse(
+            "favorite-category-list",
+            kwargs={
+                "version": "v1",
+                "category_id": 2
+            }
+        )
+        res = self.client.get(
+            url,
+            content_type="application/json"
+        )
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+        self.assertEqual(res.data['count'], 1)

--- a/favoriteapi/urls.py
+++ b/favoriteapi/urls.py
@@ -5,7 +5,8 @@ from .views import (
     LoginView,
     CategoryViewSet,
     FavoriteThingView,
-    FavoriteThingDetailView)
+    FavoriteThingDetailView,
+    FavoriteThingsList)
 
 router = DefaultRouter()
 router.register('category', CategoryViewSet, basename='category')
@@ -14,7 +15,8 @@ urlpatterns = [
     path('auth/register/', RegisterUsersView.as_view(), name="auth-register"),
     path('auth/login/', LoginView.as_view(), name="auth-login"),
     path('favorite/', FavoriteThingView.as_view(), name="create-favorite"),
-    path('favorite/<int:id>', FavoriteThingDetailView.as_view(), name="detail-favorite")
+    path('favorite/<int:id>', FavoriteThingDetailView.as_view(), name="detail-favorite"),
+    path('favorite/category/<int:category_id>', FavoriteThingsList.as_view(), name="favorite-category-list")
 ]
 
 urlpatterns += router.urls

--- a/favoriteapi/views.py
+++ b/favoriteapi/views.py
@@ -175,3 +175,18 @@ class FavoriteThingDetailView(mixins.DestroyModelMixin, generics.RetrieveAPIView
         ).update(ranking=F('ranking') - 1)
         return instance.delete()
 
+
+class FavoriteThingsList(mixins.ListModelMixin, generics.GenericAPIView):
+    serializer_class = FavoriteThingSerializer
+    permission_classes = (IsAuthenticated,)
+
+    def get_queryset(self):
+        category_id = self.kwargs['category_id']
+        queryset = Favorite.objects.filter(
+            category_id=category_id,
+            user_id=self.request.user
+        )
+        return queryset
+
+    def get(self, request, *args, **kwargs):
+        return self.list(request, *args, **kwargs)


### PR DESCRIPTION
#### What does this PR do?
- This PR is to provide an endpoint that allows a user to retrieve all their favourite things under a specific category
#### Description of Task to be completed?
- create an endpoint to get all favourite things under a category per user
- write tests to check the functionality of the code
#### How should this be manually tested?
- Navigate to the root directory and start the application using **python manage.py runserver**
- Navigate to the endpoint **http://127.0.0.1:8000/api/v1/favorite/category/:category_id** and make a get request after you provide a valid category id
- You should see a response containing all the favourite things the logged-in user has under the category
#### What are the relevant pivotal tracker stories?
[#167285522](https://www.pivotaltracker.com/story/show/167285522)
