### PR TITLE
#167327633: Get categories where a user has favourites

### DIFF
--- a/favoriteapi/tests/tests.py
+++ b/favoriteapi/tests/tests.py
@@ -183,6 +183,27 @@ class CategoryAPITest(BaseViewTest):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(response.data['detail'], "Authentication credentials were not provided.")
 
+    def test_get_categories_where_user_has_favorites(self):
+        user = User.objects.filter(username='paddy').first()
+        favorite = self.create_favorite(user=user, metadata={"size": "medium"})
+        self.user_token(
+            data={
+                "username": "paddy",
+                "password": "fakepassword"
+            })
+        url = reverse(
+            "category-list",
+            kwargs={
+                "version": "v1"
+            }
+        )
+        response = self.client.get(
+            url,
+            content_type="application/json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data[0]['category'], 'phones')
+
 
 class FavoriteAPITest(BaseViewTest):
     def test_create_first_favorite_thing_in_category_with_invalid_ranking_fails(self):

--- a/favoriteapi/urls.py
+++ b/favoriteapi/urls.py
@@ -4,6 +4,7 @@ from .views import (
     RegisterUsersView,
     LoginView,
     CategoryViewSet,
+    # CategoryListView,
     FavoriteThingView,
     FavoriteThingDetailView,
     FavoriteThingsList)

--- a/favoriteapi/views.py
+++ b/favoriteapi/views.py
@@ -59,6 +59,13 @@ class CategoryViewSet(viewsets.ModelViewSet):
     serializer_class = CategorySerializer
     permission_classes = (IsAuthenticated,)
 
+    def list(self, request, *args, **kwargs):
+        queryset = self.queryset.filter(
+            favorite__user_id=self.request.user
+        ).distinct()
+        serializer = CategorySerializer(queryset, many=True)
+        return Response(serializer.data)
+
 
 # Favorite things Related Views
 class FavoriteThingView(mixins.CreateModelMixin, generics.GenericAPIView):


### PR DESCRIPTION



#### What does this PR do?
- This PR is for the creation of the endpoint to retrieve all categories under which a user has favourites
#### Description of Task to be completed?
- create the endpoint to retrieve categories where a user has favourites
- write tests to test out the code functionality
#### How should this be manually tested?
- Start the application by going to the root directory and running **python manage.py runserver** 
- Navigate to the endpoint **http://127.0.0.1:8000/api/v1/category/** and make a GET request
- On providing the valid authentication,  you should get all the categories for the logged-in user
#### What are the relevant pivotal tracker stories?
[#167327633](https://www.pivotaltracker.com/story/show/167327633)
