### PR TITLE
#167539416: Users can edit favorite thing instance

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ django-nose = "*"
 coverage = "*"
 django-simple-history = "*"
 django-cors-headers = "*"
+cryptography = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3a96f860b6f1b80ebe84db40beb43e73af5a23415596f7d7a1c8df3fda6c4605"
+            "sha256": "afd3c35966d6874b79c34cd79d32c803e46a1cbcc19e34ce311ef889d56d3a8b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,46 @@
         ]
     },
     "default": {
+        "asn1crypto": {
+            "hashes": [
+                "sha256:2f1adbb7546ed199e3c90ef23ec95c5cf3585bac7d11fb7eb562a3fe89c64e87",
+                "sha256:9d5c20441baf0cb60a4ac34cc447c6c189024b6b4c6cd7877034f4965c464e49"
+            ],
+            "version": "==0.24.0"
+        },
+        "cffi": {
+            "hashes": [
+                "sha256:041c81822e9f84b1d9c401182e174996f0bae9991f33725d059b771744290774",
+                "sha256:046ef9a22f5d3eed06334d01b1e836977eeef500d9b78e9ef693f9380ad0b83d",
+                "sha256:066bc4c7895c91812eff46f4b1c285220947d4aa46fa0a2651ff85f2afae9c90",
+                "sha256:066c7ff148ae33040c01058662d6752fd73fbc8e64787229ea8498c7d7f4041b",
+                "sha256:2444d0c61f03dcd26dbf7600cf64354376ee579acad77aef459e34efcb438c63",
+                "sha256:300832850b8f7967e278870c5d51e3819b9aad8f0a2c8dbe39ab11f119237f45",
+                "sha256:34c77afe85b6b9e967bd8154e3855e847b70ca42043db6ad17f26899a3df1b25",
+                "sha256:46de5fa00f7ac09f020729148ff632819649b3e05a007d286242c4882f7b1dc3",
+                "sha256:4aa8ee7ba27c472d429b980c51e714a24f47ca296d53f4d7868075b175866f4b",
+                "sha256:4d0004eb4351e35ed950c14c11e734182591465a33e960a4ab5e8d4f04d72647",
+                "sha256:4e3d3f31a1e202b0f5a35ba3bc4eb41e2fc2b11c1eff38b362de710bcffb5016",
+                "sha256:50bec6d35e6b1aaeb17f7c4e2b9374ebf95a8975d57863546fa83e8d31bdb8c4",
+                "sha256:55cad9a6df1e2a1d62063f79d0881a414a906a6962bc160ac968cc03ed3efcfb",
+                "sha256:5662ad4e4e84f1eaa8efce5da695c5d2e229c563f9d5ce5b0113f71321bcf753",
+                "sha256:59b4dc008f98fc6ee2bb4fd7fc786a8d70000d058c2bbe2698275bc53a8d3fa7",
+                "sha256:73e1ffefe05e4ccd7bcea61af76f36077b914f92b76f95ccf00b0c1b9186f3f9",
+                "sha256:a1f0fd46eba2d71ce1589f7e50a9e2ffaeb739fb2c11e8192aa2b45d5f6cc41f",
+                "sha256:a2e85dc204556657661051ff4bab75a84e968669765c8a2cd425918699c3d0e8",
+                "sha256:a5457d47dfff24882a21492e5815f891c0ca35fefae8aa742c6c263dac16ef1f",
+                "sha256:a8dccd61d52a8dae4a825cdbb7735da530179fea472903eb871a5513b5abbfdc",
+                "sha256:ae61af521ed676cf16ae94f30fe202781a38d7178b6b4ab622e4eec8cefaff42",
+                "sha256:b012a5edb48288f77a63dba0840c92d0504aa215612da4541b7b42d849bc83a3",
+                "sha256:d2c5cfa536227f57f97c92ac30c8109688ace8fa4ac086d19d0af47d134e2909",
+                "sha256:d42b5796e20aacc9d15e66befb7a345454eef794fdb0737d1af593447c6c8f45",
+                "sha256:dee54f5d30d775f525894d67b1495625dd9322945e7fee00731952e0368ff42d",
+                "sha256:e070535507bd6aa07124258171be2ee8dfc19119c28ca94c9dfb7efd23564512",
+                "sha256:e1ff2748c84d97b065cc95429814cdba39bcbd77c9c85c89344b317dc0d9cbff",
+                "sha256:ed851c75d1e0e043cbf5ca9a8e1b13c4c90f3fbd863dacb01c0808e2b5204201"
+            ],
+            "version": "==1.12.3"
+        },
         "coverage": {
             "hashes": [
                 "sha256:3684fabf6b87a369017756b551cef29e505cb155ddb892a7a29277b978da88b9",
@@ -52,6 +92,28 @@
             ],
             "index": "pypi",
             "version": "==4.5.3"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:24b61e5fcb506424d3ec4e18bca995833839bf13c59fc43e530e488f28d46b8c",
+                "sha256:25dd1581a183e9e7a806fe0543f485103232f940fcfc301db65e630512cce643",
+                "sha256:3452bba7c21c69f2df772762be0066c7ed5dc65df494a1d53a58b683a83e1216",
+                "sha256:41a0be220dd1ed9e998f5891948306eb8c812b512dc398e5a01846d855050799",
+                "sha256:5751d8a11b956fbfa314f6553d186b94aa70fdb03d8a4d4f1c82dcacf0cbe28a",
+                "sha256:5f61c7d749048fa6e3322258b4263463bfccefecb0dd731b6561cb617a1d9bb9",
+                "sha256:72e24c521fa2106f19623a3851e9f89ddfdeb9ac63871c7643790f872a305dfc",
+                "sha256:7b97ae6ef5cba2e3bb14256625423413d5ce8d1abb91d4f29b6d1a081da765f8",
+                "sha256:961e886d8a3590fd2c723cf07be14e2a91cf53c25f02435c04d39e90780e3b53",
+                "sha256:96d8473848e984184b6728e2c9d391482008646276c3ff084a1bd89e15ff53a1",
+                "sha256:ae536da50c7ad1e002c3eee101871d93abdc90d9c5f651818450a0d3af718609",
+                "sha256:b0db0cecf396033abb4a93c95d1602f268b3a68bb0a9cc06a7cff587bb9a7292",
+                "sha256:cfee9164954c186b191b91d4193989ca994703b2fff406f71cf454a2d3c7327e",
+                "sha256:e6347742ac8f35ded4a46ff835c60e68c22a536a8ae5c4422966d06946b6d4c6",
+                "sha256:f27d93f0139a3c056172ebb5d4f9056e770fdf0206c2f422ff2ebbad142e09ed",
+                "sha256:f57b76e46a58b63d1c6375017f4564a28f19a5ca912691fd2e4261b3414b618d"
+            ],
+            "index": "pypi",
+            "version": "==2.7"
         },
         "django": {
             "hashes": [
@@ -125,6 +187,13 @@
             ],
             "index": "pypi",
             "version": "==2.8.3"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:9be499cf66e4bfa39b17cd4854c7911c33a51e8ef00d1e4763e4df538d1544de",
+                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
+            ],
+            "version": "==2.19"
         },
         "pyjwt": {
             "hashes": [

--- a/client/build/webpack.base.config.js
+++ b/client/build/webpack.base.config.js
@@ -8,6 +8,30 @@ module.exports = {
     app: path.resolve(__dirname, '../src/client-entry.js'),
     vendor: ['vue', 'vue-router', 'vuex', 'axios']
   },
+  optimization: {
+    splitChunks: {
+      chunks: 'async',
+      minSize: 30000,
+      maxSize: 0,
+      minChunks: 1,
+      maxAsyncRequests: 5,
+      maxInitialRequests: 3,
+      automaticNameDelimiter: '~',
+      automaticNameMaxLength: 30,
+      name: true,
+      cacheGroups: {
+        vendors: {
+          test: /[\\/]node_modules[\\/]/,
+          priority: -10
+        },
+        default: {
+          minChunks: 2,
+          priority: -20,
+          reuseExistingChunk: true
+        }
+      }
+    }
+  },
   module: {
     rules: [
       {

--- a/client/build/webpack.client.config.js
+++ b/client/build/webpack.client.config.js
@@ -1,4 +1,5 @@
 const base = require('./webpack.base.config')
+const webpack = require('webpack')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 
 const config = Object.assign({}, base, {
@@ -10,5 +11,20 @@ config.plugins.push(
     filename: 'css/[name].bundle.css'
   })
 )
+
+if (process.env.NODE_ENV === 'production') {
+  config.plugins.push(
+    new webpack.DefinePlugin({
+      'process.env': {
+        NODE_ENV: '"production"'
+      }
+    }),
+    new webpack.optimize.UglifyJsPlugin({
+      compress: {
+        warnings: false
+      }
+    })
+  )
+}
 
 module.exports = config

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1479,6 +1479,39 @@
         "object.assign": "^4.1.0"
       }
     },
+    "babel-polyfill": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
+      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
+      "requires": {
+        "babel-runtime": "^6.26.0",
+        "core-js": "^2.5.0",
+        "regenerator-runtime": "^0.10.5"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
+      }
+    },
+    "babel-runtime": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "requires": {
+        "core-js": "^2.4.0",
+        "regenerator-runtime": "^0.11.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        }
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -4,8 +4,11 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "babel-node server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "cross-env NODE_ENV=production babel-node server.js",
+    "dev": "rimraf ./dist && cross-env NODE_ENV=development babel-node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build:client": "cross-env NODE_ENV=production webpack --config ./build/webpack.client.config.js --progress --hide-modules",
+    "build": "rimraf ./dist && npm run build:client"
   },
   "keywords": [],
   "author": "",
@@ -16,6 +19,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.9.0",
     "@fortawesome/vue-fontawesome": "^0.1.6",
     "axios": "^0.19.0",
+    "babel-polyfill": "^6.26.0",
     "bulma": "^0.7.5",
     "cors": "^2.8.5",
     "dotenv": "^8.0.0",

--- a/client/server.js
+++ b/client/server.js
@@ -4,6 +4,8 @@ import fs from 'fs';
 import cors from 'cors';
 import devServer from './build/dev-server';
 
+const isProd = typeof process.env.NODE_ENV !== 'undefined' && (process.env.NODE_ENV === 'production')
+
 const app = express();
 
 app.use(cors())
@@ -12,7 +14,11 @@ const indexHTML = (() => {
   return fs.readFileSync(path.resolve(__dirname, './index.html'), 'utf-8')
 })()
 
-app.use('/dist', express.static(path.resolve(__dirname, './dist')))
+if (isProd) {
+  app.use('/', express.static(path.resolve(__dirname, './dist')))
+} else {
+  app.use('/dist', express.static(path.resolve(__dirname, './dist')))
+}
 
 devServer(app);
 

--- a/client/src/app.js
+++ b/client/src/app.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill'
 import Vue from 'vue'
 import Paginate from 'vuejs-paginate'
 import { library } from '@fortawesome/fontawesome-svg-core'

--- a/client/src/app.service.js
+++ b/client/src/app.service.js
@@ -64,6 +64,26 @@ const appService = {
           reject(err)
         })
     })
+  },
+  getFavorite (favoriteId) {
+    return new Promise((resolve, reject) => {
+      axios.get(`${config.apiUrl}${backendRoutes.FAVORITE}${favoriteId}`)
+        .then(response => {
+          resolve(response.data)
+        }).catch(err => {
+          reject(err)
+        })
+    })
+  },
+  getFavoriteAudit (favoriteId) {
+    return new Promise((resolve, reject) => {
+      axios.get(`${config.apiUrl}${backendRoutes.FAVORITE_HISTORY}${favoriteId}`)
+        .then(response => {
+          resolve(response.data.audit)
+        }).catch(err => {
+          reject(err)
+        })
+    })
   }
 }
 

--- a/client/src/constants/routes.js
+++ b/client/src/constants/routes.js
@@ -1,12 +1,15 @@
 export const backendRoutes = {
   CATEGORY: '/category/',
   FAVORITE: '/favorite/',
-  CATEGORY_FAVORITES: '/favorite/category'
+  CATEGORY_FAVORITES: '/favorite/category',
+  FAVORITE_HISTORY: '/favorite/history/'
 }
 
 export const frontendRoutes = {
   LANDING: '/',
   VIEW_CATEGORIES: '/categories',
   VIEW_CATEGORY_FAVORITES: '/category/:categoryId/favorites',
-  CREATE_FAVORITE: '/favorite'
+  CREATE_FAVORITE: '/favorite',
+  EDIT_FAVORITE: '/favorite/:favoriteId/edit',
+  VIEW_FAVORITE: '/favorite/:favoriteId/detail'
 }

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -2,9 +2,11 @@ import Vue from 'vue'
 import VueRouter from 'vue-router'
 import Landing from './theme/Landing.vue'
 import Category from './theme/Category.vue'
-import Favorites from './theme/Favorites.vue'
+import CategoryFavorites from './theme/CategoryFavorites.vue'
 import NotFound from './theme/NotFound.vue'
-import CreateEditFavorite from './theme/CreateEditFavorite.vue'
+import CreateFavorite from './theme/CreateFavorite.vue'
+import EditFavorite from './theme/EditFavorite.vue'
+import FavoriteDetail from './theme/FavoriteDetail.vue'
 import { frontendRoutes } from './constants/routes'
 
 Vue.use(VueRouter)
@@ -16,8 +18,10 @@ const router = new VueRouter({
   routes: [
     { path: frontendRoutes.VIEW_CATEGORIES, name: 'categories', component: Category },
     { path: frontendRoutes.LANDING, name: 'landing', component: Landing },
-    { path: frontendRoutes.VIEW_CATEGORY_FAVORITES, name: 'category-favorites', component: Favorites },
-    { path: frontendRoutes.CREATE_FAVORITE, name: 'favorite', component: CreateEditFavorite },
+    { path: frontendRoutes.VIEW_CATEGORY_FAVORITES, name: 'category-favorites', component: CategoryFavorites },
+    { path: frontendRoutes.CREATE_FAVORITE, name: 'favorite', component: CreateFavorite },
+    { path: frontendRoutes.EDIT_FAVORITE, name: 'favorite-edit', component: EditFavorite },
+    { path: frontendRoutes.VIEW_FAVORITE, name: 'favorite-detail', component: FavoriteDetail },
     { path: '*', component: NotFound }
   ]
 })

--- a/client/src/styles/base/_base.scss
+++ b/client/src/styles/base/_base.scss
@@ -5,3 +5,7 @@ html, body {
 body {
   font-family: Helvetica, Arial, sans-serif;
 }
+
+button:hover {
+  cursor: pointer;
+}

--- a/client/src/styles/base/_settings.scss
+++ b/client/src/styles/base/_settings.scss
@@ -1,9 +1,0 @@
-// Colors
-$blue: blue;
-$off-white: whitesmoke;
-
-// Font size
-$font-size-large: 1rem;
-
-// Spacing
-$s-size: 0.6rem;

--- a/client/src/styles/components/_navbar.scss
+++ b/client/src/styles/components/_navbar.scss
@@ -7,3 +7,7 @@
   margin-bottom: 40px;
   box-shadow: 0px 2px 10px rgba(0,0,0, .2);
 }
+
+.ctg__button {
+  margin: auto 10px;
+}

--- a/client/src/styles/styles.scss
+++ b/client/src/styles/styles.scss
@@ -1,4 +1,3 @@
-@import "./base/settings";
 @import "./base/base";
 @import "./components/landing";
 @import "./components/navbar";

--- a/client/src/theme/Category.vue
+++ b/client/src/theme/Category.vue
@@ -28,6 +28,7 @@
     </div>
   </div>
 </template>
+
 <script>
 import Header from './Header.vue'
 import SingleCategory from './CategoryItem.vue'
@@ -58,6 +59,7 @@ export default {
   }
 }
 </script>
+
 <style scoped>
   .columns {
     display: flex;

--- a/client/src/theme/CategoryFavorites.vue
+++ b/client/src/theme/CategoryFavorites.vue
@@ -26,8 +26,20 @@
             <td>{{ favorite.description.substring(0, 18).concat('...') }}</td>
             <td>{{ formatDate(favorite.created_at) }}</td>
             <td>{{ formatDate(favorite.modified_at) }}</td>
-            <td><a>Details</a></td>
-            <td><a>Edit</a></td>
+            <td>
+              <router-link
+                :to="{ name: 'favorite-detail', params: { favoriteId: favorite.id }}"
+              >
+                Details
+              </router-link>
+            </td>
+            <td>
+              <router-link
+                :to="{ name: 'favorite-edit', params: { favoriteId: favorite.id }}"
+              >
+                Edit
+              </router-link>
+            </td>
             <td><a @click="openDeleteModal(favorite)">Delete</a></td>
           </tr>
         </tbody>
@@ -47,13 +59,14 @@
     </div>
     <delete-modal
       v-show="showDeleteModal"
-      :favoriteId="selectedFavoriteId"
-      :favoriteName="selectedFavoriteName"
+      :favorite-id="selectedFavoriteId"
+      :favorite-name="selectedFavoriteName"
       @closeDeleteFavoriteModal="showDeleteModal = false"
       @loadFavorite="()=>loadCategoryFavorites()"
     />
   </div>
 </template>
+
 <script>
 import DeleteModal from './FavoriteDeleteModal.vue'
 import Header from './Header.vue'
@@ -108,12 +121,12 @@ export default {
       const categoryId = this.$route.params.categoryId
       const pageLimit = this.limit
       const offset = (num - 1) * pageLimit
-      console.log(this.limit, offset)
       this.$store.dispatch('categoryModule/getCategoryFavorites', { categoryId, pageLimit, offset })
     }
   }
 }
 </script>
+
 <style scoped>
   .container {
     display: flex;

--- a/client/src/theme/CategoryItem.vue
+++ b/client/src/theme/CategoryItem.vue
@@ -5,7 +5,7 @@
         <slot name="category" />
       </p>
     </div>
-    <footer class="card-footer">
+    <footer class="card-footer has-background-white-bis">
       <p
         class="card-footer-item"
       >
@@ -14,11 +14,13 @@
     </footer>
   </div>
 </template>
+
 <script>
 export default {
   name: 'CategoryItem'
 }
 </script>
+
 <style scoped>
   .card {
     padding-bottom: 40px;

--- a/client/src/theme/CategoryModal.vue
+++ b/client/src/theme/CategoryModal.vue
@@ -38,7 +38,7 @@
       </section>
       <footer class="modal-card-foot">
         <button
-          class="button is-success"
+          class="button is-primary"
           @click="addCategory()"
         >
           Save
@@ -80,6 +80,7 @@ export default {
             position: 'top-right'
           })
           this.categoryName = ''
+          this.$router.push({ name: 'categories' })
         })
         .catch((err) => this.errors.record(err.response.data))
     }

--- a/client/src/theme/CreateFavorite.vue
+++ b/client/src/theme/CreateFavorite.vue
@@ -112,7 +112,7 @@
                 <font-awesome-icon
                   v-show="k == metadata.length-1"
                   icon="plus-square"
-                  class="has-text-success icon is-medium"
+                  class="has-text-primary icon is-medium"
                   @click="add(k)"
                 />
               </span>
@@ -128,7 +128,7 @@
       <div class="field">
         <div class="control">
           <button
-            class="button is-success"
+            class="button is-primary"
             @click="addFavorite()"
           >
             Create Favorite
@@ -138,6 +138,7 @@
     </div>
   </div>
 </template>
+
 <script>
 import Vue from 'vue'
 import VueToast from 'vue-toast-notification'
@@ -155,7 +156,6 @@ export default {
   },
   data () {
     return {
-      isEdit: false,
       title: '',
       description: '',
       category: 0,
@@ -197,7 +197,9 @@ export default {
       const category = this.category
       const ranking = parseInt(this.ranking)
       this.metadata.forEach(entry => {
-        metadata[entry.key] = entry.value
+        if (entry.key !== '' && entry.value !== '') {
+          metadata[entry.key] = entry.value
+        }
       })
       this.$store.dispatch('favoriteModule/addFavorite', {
         title,
@@ -211,18 +213,8 @@ export default {
           type: 'success',
           position: 'top-right'
         })
-        this.title = ''
-        this.description = ''
-        this.category = 0
-        this.ranking = null
-        this.metadata = [
-          {
-            key: '',
-            value: ''
-          }
-        ]
+        this.$router.push({ name: 'category-favorites', params: { categoryId: category } })
       }).catch((err) => {
-        console.log(err.response.data)
         if (err.response.data.status) {
           Vue.$toast.open({
             message: err.response.data.message,
@@ -236,6 +228,7 @@ export default {
   }
 }
 </script>
+
 <style scoped>
   .container {
     width: 30%;

--- a/client/src/theme/EditFavorite.vue
+++ b/client/src/theme/EditFavorite.vue
@@ -1,0 +1,302 @@
+<template>
+  <div>
+    <heading />
+    <div class="back">
+      <a
+        class="button is-link"
+        @click="goBack"
+      >
+        {{ back }}
+      </a>
+    </div>
+    <div class="container">
+      <h1>Edit Favorite</h1>
+      <div class="field">
+        <label class="label">Title</label>
+        <div class="control">
+          <input
+            v-model="title"
+            class="input"
+            type="text"
+            placeholder="Favorite thing name"
+            @keydown="errors.clear('title')"
+          >
+        </div>
+        <span
+          class="help is-danger"
+          v-text="errors.get('title')"
+        />
+      </div>
+
+      <div class="field">
+        <label class="label">Ranking</label>
+        <div class="control">
+          <input
+            v-model="ranking"
+            class="input"
+            type="email"
+            placeholder="Favorite thing ranking"
+            @keydown="errors.clear('ranking')"
+          >
+        </div>
+        <span
+          class="help is-danger"
+          v-text="errors.get('ranking')"
+        />
+      </div>
+
+      <div class="field">
+        <label class="label">Category</label>
+        <div class="control">
+          <div
+            class="select"
+            @keydown="errors.clear('category')"
+          >
+            <select v-model="category">
+              <option value="0">
+                Select dropdown
+              </option>
+              <option
+                v-for="categoryItem in categories"
+                :key="categoryItem.id"
+                :value="categoryItem.id"
+              >
+                {{ categoryItem.category }}
+              </option>
+            </select>
+          </div>
+          <span
+            class="help is-danger"
+            v-text="errors.get('category')"
+          />
+        </div>
+      </div>
+
+      <div class="field">
+        <label class="label">Description</label>
+        <div class="control">
+          <textarea
+            v-model="description"
+            class="textarea"
+            placeholder="Favorite thing description"
+            @keydown="errors.clear('description')"
+          />
+        </div>
+        <span
+          class="help is-danger"
+          v-text="errors.get('description')"
+        />
+      </div>
+      <div class="field">
+        <label class="label">Metadata</label>
+        <div
+          v-for="(data,k) in metadata"
+          :key="k"
+          class="form-group"
+        >
+          <div class="meta">
+            <div class="meta meta-input">
+              <input
+                v-model="data.key"
+                type="text"
+                class="input meta-input"
+                placeholder="key"
+              >
+              <input
+                v-model="data.value"
+                type="text"
+                class="input"
+                placeholder="value"
+              >
+            </div>
+            <div>
+              <span class="meta">
+                <font-awesome-icon
+                  v-show="k || ( !k && metadata.length > 1)"
+                  icon="minus-square"
+                  class="has-text-danger icon is-medium"
+                  @click="remove(k)"
+                />
+                <font-awesome-icon
+                  v-show="k == metadata.length-1"
+                  icon="plus-square"
+                  class="has-text-primary icon is-medium"
+                  @click="add(k)"
+                />
+              </span>
+            </div>
+          </div>
+        </div>
+        <span
+          class="help is-danger"
+          v-text="errors.get('metadata')"
+        />
+      </div>
+      <br>
+      <div class="field">
+        <div class="control">
+          <button
+            class="button is-primary"
+            @click="editFavorite()"
+          >
+            Edit Favorite
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Vue from 'vue'
+import axios from 'axios'
+import VueToast from 'vue-toast-notification'
+import 'vue-toast-notification/dist/index.css'
+import { mapState } from 'vuex'
+import Header from './Header.vue'
+import Errors from '../helpers/errors'
+import { backendRoutes } from '../constants/routes'
+import config from '../config'
+
+Vue.use(VueToast)
+
+export default {
+  name: 'EditFavorite',
+  components: {
+    heading: Header
+  },
+  data () {
+    return {
+      back: '<< Back',
+      title: '',
+      description: '',
+      category: 0,
+      ranking: null,
+      metadata: [
+        {
+          key: '',
+          value: ''
+        }
+      ],
+      errors: new Errors()
+    }
+  },
+  computed: {
+    ...mapState({
+      categories: state => state.categoryModule.categories
+    })
+  },
+  watch: {
+    '$route' (to, from) {
+      this.loadCategories()
+      this.getFavorite()
+    }
+  },
+  created () {
+    this.loadCategories()
+    this.getFavorite()
+  },
+  methods: {
+    add (index) {
+      this.metadata.push({
+        key: '',
+        value: ''
+      })
+    },
+    remove (index) {
+      this.metadata.splice(index, 1)
+    },
+    goBack () {
+      this.$router.push({ name: 'category-favorites', params: { categoryId: this.category } })
+    },
+    loadCategories () {
+      this.$store.dispatch('categoryModule/getCategories')
+    },
+    getFavorite () {
+      const favoriteId = this.$route.params.favoriteId
+      return new Promise((resolve, reject) => {
+        axios.get(`${config.apiUrl}${backendRoutes.FAVORITE}${favoriteId}`)
+          .then(response => {
+            resolve(response.data)
+            const favorite = response.data
+            this.title = favorite.title
+            this.description = favorite.description
+            this.category = favorite.category
+            this.ranking = favorite.ranking
+            if (favorite.metadata) {
+              for (const [metaKey, metaValue] of Object.entries(favorite.metadata)) {
+                this.metadata.unshift({
+                  key: metaKey,
+                  value: metaValue
+                })
+              }
+            }
+          }).catch(err => {
+            reject(err)
+          })
+      })
+    },
+    editFavorite () {
+      const favoriteId = this.$route.params.favoriteId
+      const metadata = {}
+      const title = this.title
+      const description = this.description
+      const category = this.category
+      const ranking = parseInt(this.ranking)
+      this.metadata.forEach(entry => {
+        if (entry.key !== '' && entry.value !== '') {
+          metadata[entry.key] = entry.value
+        }
+      })
+      return new Promise((resolve, reject) => {
+        axios.put(`${config.apiUrl}${backendRoutes.FAVORITE}${favoriteId}`, {
+          title,
+          description,
+          category,
+          ranking,
+          metadata
+        }).then(response => {
+          resolve(response.data)
+          Vue.$toast.open({
+            message: 'Favorite edited Successfully',
+            type: 'success',
+            position: 'top-right'
+          })
+          this.$router.push({ name: 'category-favorites', params: { categoryId: category } })
+        }).catch(err => {
+          reject(err)
+          if (err.response.data.status) {
+            Vue.$toast.open({
+              message: err.response.data.message,
+              type: 'error',
+              position: 'top-right'
+            })
+          }
+          this.errors.record(err.response.data)
+        })
+      })
+    }
+  }
+}
+</script>
+
+<style scoped>
+  .container {
+    width: 30%;
+  }
+  .meta {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    margin-bottom: 5px;
+  }
+  .meta-input {
+    margin-right: 15px;
+  }
+  .icon:hover {
+    cursor: pointer;
+  }
+  .back {
+    padding-left: 250px;
+  }
+</style>

--- a/client/src/theme/FavoriteDeleteModal.vue
+++ b/client/src/theme/FavoriteDeleteModal.vue
@@ -42,6 +42,7 @@
     </div>
   </div>
 </template>
+
 <script>
 import Vue from 'vue'
 import VueToast from 'vue-toast-notification'

--- a/client/src/theme/FavoriteDetail.vue
+++ b/client/src/theme/FavoriteDetail.vue
@@ -1,0 +1,127 @@
+<template>
+  <div>
+    <heading />
+    <div class="back">
+      <a
+        class="button is-link"
+        @click="goBack"
+      >
+        {{ back }}
+      </a>
+    </div>
+    <div class="container has-background-light">
+      <div class="detail has-background-white-ter">
+        <h1><strong>{{ favorite.title }}</strong></h1>
+        <h2><strong>Description:</strong> {{ favorite.description }}</h2>
+        <hr>
+        <h2><strong>Ranking:</strong> {{ favorite.ranking }}</h2>
+        <hr>
+        <h2><strong>Category:</strong> {{ favorite.category_name.toLowerCase() }}</h2>
+        <hr>
+        <h2><strong>Created:</strong> {{ formatDate(favorite.created_at) }}</h2>
+        <hr>
+        <h2><strong>Modified:</strong> {{ formatDate(favorite.modified_at) }}</h2>
+        <hr>
+        <h2><strong>Metadata:</strong></h2>
+        <div
+          v-for="(data, index) in Object.entries(favorite.metadata)"
+          :key="index"
+        >
+          <h4>{{ data[0] }}: {{ data[1] }}</h4>
+        </div>
+      </div>
+      <div
+        v-if="audit[0]"
+        class="container audit has-background-white-ter"
+      >
+        <h1>Audit-Log</h1>
+        <ol
+          v-for="(singleAudit,index) in audit"
+          :key="index"
+          type="1"
+        >
+          <li
+            class="has-text-primary"
+          >
+            {{ singleAudit }}
+          </li>
+        </ol>
+      </div>
+      <div
+        v-else
+      >
+        <h1>Audit-Log</h1>
+        <h2>No audit log for this favorite yet, edit it to see the logs</h2>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import moment from 'moment'
+import { mapGetters } from 'vuex'
+import Header from './Header.vue'
+
+export default {
+  name: 'FavoriteDetailView',
+  components: {
+    heading: Header
+  },
+  data () {
+    return {
+      back: '<< Back'
+    }
+  },
+  computed: {
+    ...mapGetters({
+      favorite: 'favoriteModule/favorite',
+      audit: 'favoriteModule/historyLog'
+    })
+  },
+  watch: {
+    '$route' (to, from) {
+      this.readMeta()
+    }
+  },
+  created () {
+    this.getFavorite()
+    this.getFavoriteLog()
+  },
+  methods: {
+    getFavorite () {
+      const favoriteId = this.$route.params.favoriteId
+      this.$store.dispatch('favoriteModule/getFavorite', favoriteId)
+    },
+    getFavoriteLog () {
+      const favoriteId = this.$route.params.favoriteId
+      this.$store.dispatch('favoriteModule/getFavoriteAudit', favoriteId)
+    },
+    goBack () {
+      this.$router.push({ name: 'category-favorites', params: { categoryId: this.favorite.category } })
+    },
+    formatDate (date) {
+      return moment(date).format('L')
+    }
+  }
+}
+</script>
+
+<style scoped>
+  .container {
+    width: 50%;
+    padding: 15px;
+  }
+  .audit {
+    width: 100%;
+    padding: 0px 10px 5px 10px;
+    max-height: 500px;
+    overflow: scroll;
+  }
+  .detail {
+    padding: 0px 15px 5px 15px;
+    width: 90%;
+  }
+  .back {
+    padding-left: 250px;
+  }
+</style>

--- a/client/src/theme/Header.vue
+++ b/client/src/theme/Header.vue
@@ -11,7 +11,13 @@
             class="nav-item is-tab"
             to="/"
           >
-            <h1>Favorite Things App</h1>
+            <h1>Favorite Things</h1>
+          </router-link>
+          <router-link
+            class="button is-primary ctg__button"
+            to="/categories"
+          >
+            <p>View Categories</p>
           </router-link>
         </div>
       </div>
@@ -46,6 +52,7 @@
     />
   </div>
 </template>
+
 <script>
 import categoryModal from './CategoryModal.vue'
 export default {
@@ -60,6 +67,7 @@ export default {
   }
 }
 </script>
+
 <style lang="scss" scoped>
   .navbar-brand {
     padding: 0 0.8125rem;

--- a/client/src/theme/Landing.vue
+++ b/client/src/theme/Landing.vue
@@ -29,6 +29,7 @@
     </nav>
   </div>
 </template>
+
 <script>
 export default {
   name: 'Landing'

--- a/client/src/theme/Layout.vue
+++ b/client/src/theme/Layout.vue
@@ -3,6 +3,7 @@
     <router-view />
   </div>
 </template>
+
 <script>
 export default {
   name: 'Layout'

--- a/client/src/theme/NotFound.vue
+++ b/client/src/theme/NotFound.vue
@@ -1,8 +1,17 @@
 <template>
-  <div>Oops, Page not found!</div>
+  <div>
+    <heading />
+    <h1>Oops, Page not found!</h1>
+  </div>
 </template>
+
 <script>
+import Header from './Header.vue'
+
 export default {
-  name: 'NotFoundPage'
+  name: 'NotFoundPage',
+  components: {
+    heading: Header
+  }
 }
 </script>

--- a/client/src/vuex/favorite.js
+++ b/client/src/vuex/favorite.js
@@ -1,17 +1,44 @@
 import appService from '../app.service.js'
 
 const state = {
-  favorite: {}
+  favorite: {},
+  historyLog: []
+}
+
+const getters = {
+  favorite: state => state.favorite,
+  historyLog: state => state.historyLog
 }
 
 const actions = {
   addFavorite ({ commit }, favoriteData) {
     return appService.addFavorite(favoriteData).then(() => {})
+  },
+  getFavorite ({ commit }, favoriteId) {
+    return appService.getFavorite(favoriteId).then(favorite => {
+      commit('getFavorite', favorite)
+    })
+  },
+  getFavoriteAudit ({ commit }, favoriteId) {
+    return appService.getFavoriteAudit(favoriteId).then(auditLog => {
+      commit('getFavoriteAudit', auditLog)
+    })
+  }
+}
+
+const mutations = {
+  getFavorite (state, favorite) {
+    state.favorite = favorite
+  },
+  getFavoriteAudit (state, auditLog) {
+    state.historyLog = auditLog
   }
 }
 
 export default {
   namespaced: true,
   state,
-  actions
+  actions,
+  mutations,
+  getters
 }

--- a/favoriteapi/models.py
+++ b/favoriteapi/models.py
@@ -38,5 +38,9 @@ class Favorite(models.Model):
     def __str__(self):
         return self.title
 
+    @property
+    def category_name(self):
+        return self.category.category
+
     class Meta:
         ordering = ['ranking']

--- a/favoriteapi/serializers.py
+++ b/favoriteapi/serializers.py
@@ -17,10 +17,11 @@ class CategorySerializer(serializers.ModelSerializer):
 
 
 class FavoriteThingSerializer(serializers.ModelSerializer):
+    category_name = serializers.ReadOnlyField()
+
     class Meta:
         model = Favorite
         fields = '__all__'
-        read_only_fields = ['user']
 
     def validate_metadata(self, metadata):
         valid_types = [str, int, datetime.date, enum.Enum]

--- a/favoriteapi/tests/test_views.py
+++ b/favoriteapi/tests/test_views.py
@@ -467,4 +467,4 @@ class AuditViewTest(BaseViewTest):
         )
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertIn("audit", res.data)
-        self.assertIn('title changed from tecno to xiaoming', res.data["audit"])
+        self.assertIn('Title changed from tecno to xiaoming', res.data["audit"])

--- a/favoriteapi/views.py
+++ b/favoriteapi/views.py
@@ -45,7 +45,7 @@ class FavoriteThingView(mixins.CreateModelMixin, generics.GenericAPIView):
         )
         if ranking != 1 and not existing_favorites:
             raise_error(
-                message=f'The first valid ranking for a favorite in this category is 1'
+                message=f'The first valid ranking for a favorite is 1'
             )
         if not existing_favorites:
             return self.create(request, *args, **kwargs)
@@ -82,7 +82,9 @@ class FavoriteThingDetailView(mixins.DestroyModelMixin, generics.RetrieveAPIView
 
     def put(self, request, *args, **kwargs):
         favorite_thing_id = kwargs['id']
+        print(favorite_thing_id)
         new_ranking = request.data.get('ranking')
+        print(request.data)
         favorite_to_update = get_object_or_404(Favorite, id=favorite_thing_id)
         previous_ranking = favorite_to_update.ranking
 
@@ -170,7 +172,7 @@ class FavoriteThingAudit(APIView):
             delta = new_history.diff_against(old_history)
             changes = changes + delta.changes
         for change in changes:
-            response.append(f'{change.field} changed from {change.old} to {change.new}')
+            response.append(f'{change.field.capitalize()} changed from {change.old} to {change.new}')
         return Response({
             "audit": response
         })


### PR DESCRIPTION




#### What does this PR do?
- This PR enables users to be able to update favorite things instances
#### Description of Task to be completed?
- write code to implement the functionality
- add UI implementation to supplement the functionality
#### How should this be manually tested?
- On your local version of this project
- Startup the backend server using **python manage.py runserver**
- Navigate into the client directory and start-up webpack using **npm start**
- Click on the `Get started` button
- Navigate to a category's favorites display page
- Click on the `Edit` button
- You should see a form to enter the details needed
- On supplying valid data and clicking on the Edit Favorite button, then the favorite should be updated.
#### What are the relevant pivotal tracker stories?
[#167539416](https://www.pivotaltracker.com/story/show/167539416)